### PR TITLE
chore: add costcenter 7151 to catalog-info

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,15 @@
+# For more information about the available options please visit: http://go/catalog-info (VPN required)
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  annotations:
+    github.com/project-slug: Unity-Technologies/go-lager-internal
+    backstage.io/techdocs-ref: dir:.
+  name: go-lager-internal
+  description: "Logs (from golang) in JSON, easy for computers to parse, people to read, programmers to generate.  Efficient."
+  labels:
+    costcenter: "7151"
+spec:
+  type: service
+  lifecycle: experimental
+  owner: Unity-Technologies/unity-services-foundation


### PR DESCRIPTION
## Summary

- Add `costcenter: "7151"` to `catalog-info.yaml` for Backstage cost tracking

This was generated automatically to ensure all repos under the Services Foundation team have the correct costcenter label.
